### PR TITLE
Avoid error if no history folder

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -10,7 +10,7 @@ const userDir = '/addon_configs/cf6b56a3_linky';
 export async function getMeterHistory(prm: string): Promise<EnergyDataPoint[]> {
   if (!existsSync(baseDir)) {
     debug(`Cannot find folder ${userDir}`);
-    return;
+    return [];
   }
   const files = readdirSync(baseDir).filter((file) => file.endsWith('.csv'));
   debug(`Found ${files.length} CSV ${files.length > 1 ? 'files' : 'file'} in ${userDir}`);


### PR DESCRIPTION
During the docker manual start, we only need the `/data` folder mount volume.
So `/config` and `/addon_configs/cf6b56a3_linky` doesn't not exist.

```
/linky # node --trace-exit --trace-uncaught --experimental-modules dist/index.js
HA Linky is starting
Connection with Home Assistant established
PRM 05182489143190 found in configuration for consumption
[01/03 10:59] New PRM detected, historical consumption data import is starting
Cannot find folder /addon_configs/cf6b56a3_linky
TypeError: Cannot read properties of undefined (reading 'length')
(node:110) WARNING: Exited the environment with code 1
    at exit (node:internal/process/per_thread:197:13)
    at file:///linky/dist/index.js:106:13
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

So I've change this line to have no error.

Best regards
Azlux