### PR TITLE
ajoute le timestamp du log globalement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ async function main() {
 
   async function init(config: MeterConfig) {
     info(
-      `[${dayjs().format('DD/MM HH:mm')}] New PRM detected, historical ${
+      `New PRM detected, historical ${
         config.production ? 'production' : 'consumption'
       } data import is starting`,
     );
@@ -57,7 +57,7 @@ async function main() {
 
   async function sync(config: MeterConfig) {
     info(
-      `[${dayjs().format('DD/MM HH:mm')}] Synchronization started for ${
+      `Synchronization started for ${
         config.production ? 'production' : 'consumption'
       } data`,
     );

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,7 +1,8 @@
 import { Chalk } from 'chalk';
+import dayjs from 'dayjs';
 
 const chalk = new Chalk({ level: 1 });
-export const debug = (str: string) => console.info(chalk.white(str));
-export const info = (str: string) => console.info(chalk.blue(str));
-export const warn = (str: string) => console.warn(chalk.yellow(str));
-export const error = (str: string) => console.error(chalk.red(str));
+export const debug = (str: string) => console.info('[', dayjs().format('DD/MM HH:mm:ss'), ']', chalk.white(str));
+export const info = (str: string) => console.info('[', dayjs().format('DD/MM HH:mm:ss'), ']', chalk.blue(str));
+export const warn = (str: string) => console.warn('[', dayjs().format('DD/MM HH:mm:ss'), ']', chalk.yellow(str));
+export const error = (str: string) => console.error('[', dayjs().format('DD/MM HH:mm:ss'), ']', chalk.red(str));


### PR DESCRIPTION
Bonjour,
J'ai noté que les timestamps des logs ne sont pas sur tous les messages. J'ai donc retiré les timestamps d'index.ts pour les ajouter à log.ts.
Je ne suis pas sûr que la PR peut être accepté tel quelle, mais ca donne une idée de comment faire.
J'ai également ajouté les secondes.