### PR TITLE
Fix recorder/import_statistics metadata deprecation (HA Core 2026.11)

### DIFF
--- a/src/ha.ts
+++ b/src/ha.ts
@@ -107,12 +107,19 @@ export class HomeAssistantClient {
     await this.sendMessage({
       type: 'recorder/import_statistics',
       metadata: {
+        // has_mean is deprecated in favor of mean_type, but kept for compatibility with older HA Core versions
         has_mean: false,
+        // mean_type replaces has_mean since HA Core 2025.11 (0 = none, 1 = arithmetic, 2 = circular).
+        // Linky statistics are cumulative sums (energy / costs), so there is no averaging.
+        mean_type: 0,
         has_sum: true,
         name: isCost ? `${name} (costs)` : name,
         source: statisticId.split(':')[0],
         statistic_id: statisticId,
         unit_of_measurement: isCost ? '€' : 'Wh',
+        // unit_class must be provided since HA Core 2025.11. 'energy' matches the Wh unit;
+        // monetary costs (€) have no Home Assistant unit conversion class, so null is used.
+        unit_class: isCost ? null : 'energy',
       },
       stats,
     });


### PR DESCRIPTION
Home Assistant now warns when `recorder/import_statistics` is called without `mean_type` and `unit_class` in metadata.

Fixes #161.
Fixes #182.

The imported Linky statistics are cumulative sums, not averages, so this PR adds:

- `mean_type: 0`
- `unit_class: 'energy'` for Wh-based energy statistics
- `unit_class: null` for cost statistics in €

The existing `has_mean: false` field is kept for backward compatibility with older Home Assistant versions.

This does not change:

- Linky data retrieval logic
- entity names
- statistic IDs
- existing units

Validation:

- Static review of the WebSocket payload sent to `recorder/import_statistics`
- Verified that `mean_type` and `unit_class` are now included in the metadata
- Local Node/npm checks were not run on the patch machine because Node/npm were unavailable

Context:

Home Assistant deprecated metadata without `mean_type` and `unit_class`; the current behavior triggers daily Recorder warnings and is expected to stop working in HA Core 2026.11.
